### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/vix-4800/rector-vsc/security/code-scanning/3](https://github.com/vix-4800/rector-vsc/security/code-scanning/3)

To fix this problem, explicitly set a minimal `permissions:` block in the workflow file to enforce the principle of least privilege for the `GITHUB_TOKEN`. The best way to do this is to add a `permissions:` key at the root of the workflow (just after the `name:` and possibly before `on:`), making it apply to all jobs by default. For standard CI jobs, `contents: read` is the recommended minimal setting, unless additional permissions are required (which do not appear necessary based on the steps in this workflow). The change only involves adding a new YAML block at the start of `.github/workflows/ci.yml` and does not affect any existing operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
