### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/vix-4800/rector-vsc/security/code-scanning/2](https://github.com/vix-4800/rector-vsc/security/code-scanning/2)

The optimal fix is to explicitly limit GITHUB_TOKEN permissions for this workflow to the minimum needed. Since all steps in this linting workflow are read-only (checking out code, setting up Node, installing dependencies, running linters and TypeScript compilation), the workflow only requires read access to repository contents. Add a `permissions` block specifying `contents: read` either at the workflow root (top-level, so all jobs inherit it) or at the job level. For clarity and maintainability, it's preferable to set it at the root of the workflow, immediately after the workflow name and before the `on:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
