### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/vix-4800/rector-vsc/security/code-scanning/1](https://github.com/vix-4800/rector-vsc/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow so that the permissions granted to the GITHUB_TOKEN are kept to the minimum required for the actions in this workflow. Best practice is to add this block at the workflow root unless individual jobs require different permissions. For a release workflow, typically read access is sufficient for most steps, but tokens will need write permissions for the actual release (`softprops/action-gh-release`) and uploading the artifact (`actions/upload-artifact`). At a minimum, you should add a root-level `permissions` block, and if write access is required to contents or releases, specify them as needed. A good starting point is:

```yaml
permissions:
  contents: write
  packages: read
```
or, if you want to be stricter and only grant exactly what's required for releases:
```yaml
permissions:
  contents: write
  issues: read
  pull-requests: read
```

For absolute minimal starting point (and to satisfy the CodeQL warning), you may use:
```yaml
permissions:
  contents: read
```
but this may break some steps if they require write powers.

Since this workflow is packaging and publishing a release, safest is to use:
```yaml
permissions:
  contents: write
```
Add this block directly after the `name` field and before `on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
